### PR TITLE
Implement arXiv ID pagination to overcome ADS API 2000-row limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+Your goal is to refactor the JWST Preprint DOI automator. 
+
+## Workflow
+- Do all work in a git branch, "dev-refactor".
+- Work interactively with the user.
+- Do not try to do *perfect* software design; just make it good enough and simple to understand.
+- Eventually, iterate with the user on writing unit tests.
+- Do *not* include Claude in commit messages, i.e., DO NOT WRITE `Co-Authored-By: Claude` anywhere
+
+## Scope
+- Focus on refactoring and enhancing the code in the `jwst_preprint_analyzer/` module.
+- Current priority: Implement arXiv ID pagination to overcome ADS API 2000-row limit
+- You may look at the README, and if needed, the prompt files. 
+- Ignore all results, notebooks, and other data sources. 
+
+## Refactoring Objectives
+
+### 1. Module Restructuring
+- **Current State**: Monolithic Python script
+- **Target**: Well-organized multi-file module structure
+- **Follow**: Python packaging best practices (PEP 8, separation of concerns)
+- **Consider**: 
+  - `__init__.py` for package structure
+  - Separate modules for distinct functionality
+  - Clear import hierarchy
+  - Avoid circular dependencies
+
+### 2. Code Cleanup
+- **Remove**: Excessive comments that don't add value
+- **Preserve**: Comments explaining non-trivial business logic
+- **Focus**: Self-documenting code through clear naming and structure
+
+### 3. Documentation Updates
+- **Phase 1**: Reference existing README.md (well-written baseline)
+- **Phase 2**: Update README.md to reflect new structure post-refactoring
+- **Maintain**: API documentation and usage examples
+
+## Key Principles
+- **Single Responsibility**: Each module should have one clear purpose
+- **DRY**: Eliminate code duplication across modules
+- **Maintainability**: Code should be easy to understand and modify
+
+## Current Implementation Task
+Implement arXiv ID pagination to overcome ADS API 2000-row limit:
+- Enhance existing `--year-month` mode with pagination based on arXiv ID patterns
+- Break queries into chunks like `arXiv:YYMM.0*`, `arXiv:YYMM.1*`, etc. to stay under 2000-row limit
+- ArXiv IDs don't reflect submission dates, so date-range queries via ADS API are not feasible
+- ADS API only provides `pubdate` (publication date) not arXiv submission date
+- Pagination combined with existing filtering will keep result sets manageable
+- Maintain existing query semantics and report format
+- No rate limiting concerns for human usage patterns

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Example:
 jwst-preprint-analyzer --year-month 2024-01 --output-dir ./analysis_results
 ```
 
+### Batch Mode with Pagination (by Month)
+The `--year-month` mode automatically handles large result sets by implementing arXiv ID pagination. When analyzing months with many papers, the system breaks queries into chunks (e.g., `arXiv:YYMM.0*`, `arXiv:YYMM.1*`) to stay under the ADS API 2000-row limit. This pagination is transparent to users and maintains full coverage of all papers for the specified month.
+
 ### Single Paper Mode (by arXiv ID)
 Analyzes a single preprint specified by its arXiv ID.
 ```bash
@@ -42,7 +45,7 @@ jwst-preprint-analyzer [-h] (--year-month YEAR_MONTH | --arxiv-id ARXIV_ID)
 ```
 
 **Mode Selection (choose one):**
--   `--year-month YEAR_MONTH`: Month to analyze in `YYYY-MM` format (e.g., `2024-01`) for batch processing.
+-   `--year-month YEAR_MONTH`: Month to analyze in `YYYY-MM` format (e.g., `2024-01`) for batch processing. Automatically implements arXiv ID pagination to handle large result sets and overcome ADS API 2000-row limit.
 -   `--arxiv-id ARXIV_ID`: Specific arXiv ID (e.g., `2301.12345`) to process for single paper analysis.
 
 **General Options:**

--- a/jwst_preprint_analyzer/clients/ads.py
+++ b/jwst_preprint_analyzer/clients/ads.py
@@ -18,19 +18,34 @@ class ADSClient:
         self.base_url = "https://api.adsabs.harvard.edu/v1/search/query"
         
     def get_papers_for_month(self, year_month: str) -> List[Dict[str, str]]:
-        """Fetch list of astronomy papers for the specified month from ADS."""
-        logger.info(f"Fetching paper list for {year_month}")
+        """Fetch list of astronomy papers for the specified month from ADS using pagination."""
+        logger.info(f"Fetching paper list for {year_month} with arXiv ID pagination")
 
         try:
             year_full, month = year_month.split('-')
             if len(year_full) != 4 or not year_full.isdigit() or len(month) != 2 or not month.isdigit():
                 raise ValueError("Invalid format")
             year_short = year_full[2:]  # Get the last two digits of the year (YY)
-            arxiv_pattern = f"arXiv:{year_short}{month}.*"
         except ValueError:
             logger.error("`year_month` argument format must be YYYY-MM")
             raise ValueError("`year_month` argument format must be YYYY-MM")
 
+        all_papers = []
+        
+        # Paginate using first digit of paper number: 0*, 1*, 2*, ..., 9*
+        for digit in range(10):
+            arxiv_pattern = f"arXiv:{year_short}{month}.{digit}*"
+            logger.info(f"Querying papers with pattern: {arxiv_pattern}")
+            
+            papers_for_digit = self._query_papers_by_pattern(arxiv_pattern, year_month)
+            logger.info(f"Found {len(papers_for_digit)} papers for pattern {arxiv_pattern}")
+            all_papers.extend(papers_for_digit)
+
+        logger.info(f"Found total of {len(all_papers)} valid papers for {year_month}")
+        return all_papers
+
+    def _query_papers_by_pattern(self, arxiv_pattern: str, context: str) -> List[Dict[str, str]]:
+        """Query ADS for papers matching a specific arXiv pattern."""
         params = {
             "q": "database:astronomy",
             "fq": [f'identifier:"{arxiv_pattern}"'],
@@ -44,10 +59,10 @@ class ADSClient:
             response = requests.get(self.base_url, params=params, headers=headers, timeout=30)
             response.raise_for_status()
         except requests.exceptions.Timeout:
-            logger.error("ADS API request timed out.")
+            logger.error(f"ADS API request timed out for pattern {arxiv_pattern}")
             return []
         except requests.exceptions.RequestException as e:
-            logger.error(f"ADS API request failed: {e}")
+            logger.error(f"ADS API request failed for pattern {arxiv_pattern}: {e}")
             if hasattr(e, 'response') and e.response is not None:
                 logger.error(f"ADS Response Status: {e.response.status_code}")
                 logger.error(f"ADS Response Body: {e.response.text}")
@@ -58,12 +73,12 @@ class ADSClient:
         try:
             data = response.json()
         except json.JSONDecodeError:
-            logger.error(f"Failed to decode JSON response from ADS: {response.text[:500]}")
+            logger.error(f"Failed to decode JSON response from ADS for pattern {arxiv_pattern}: {response.text[:500]}")
             return []
 
         papers = []
         if 'response' not in data or 'docs' not in data['response']:
-            logger.warning(f"Unexpected ADS response format for {year_month}")
+            logger.warning(f"Unexpected ADS response format for pattern {arxiv_pattern}")
             return []
 
         for doc in data['response']['docs']:
@@ -85,5 +100,5 @@ class ADSClient:
             elif arxiv_id:
                 logger.warning(f"Extracted potential arXiv ID '{arxiv_id}' has unexpected format. Skipping.")
 
-        logger.info(f"Found {len(papers)} valid papers")
         return papers
+


### PR DESCRIPTION
Replace date-range approach with arXiv ID pagination that breaks year-month queries into chunks (YYMM.0*, YYMM.1*, etc.). This ensures complete coverage while staying under the 2000-row ADS API limit.

Tested that this works, e.g.,

```
 jwst-preprint-analyzer --year-month 2025-05 --output-dir ./test_results                                  (base)
2025-06-30 10:39:01,830 - INFO - HTTP Request: GET https://api.cohere.com/v1/models "HTTP/1.1 200 OK"
2025-06-30 10:39:01,840 - INFO - Loading prompts from directory: prompts
2025-06-30 10:39:01,842 - INFO - Starting analysis for 2025-05...
2025-06-30 10:39:01,842 - INFO - Fetching paper list for 2025-05 with arXiv ID pagination
2025-06-30 10:39:01,842 - INFO - Querying papers with pattern: arXiv:2505.0*
2025-06-30 10:39:04,425 - INFO - Found 939 papers for pattern arXiv:2505.0*
2025-06-30 10:39:04,425 - INFO - Querying papers with pattern: arXiv:2505.1*
2025-06-30 10:39:06,491 - INFO - Found 701 papers for pattern arXiv:2505.1*
2025-06-30 10:39:06,492 - INFO - Querying papers with pattern: arXiv:2505.2*
2025-06-30 10:39:07,274 - INFO - Found 370 papers for pattern arXiv:2505.2*\
[...]
2025-06-30 10:39:09,301 - INFO - Found total of 2010 valid papers for 2025-05
2025-06-30 10:39:09,301 - INFO - Processing paper 1/2010: 2505.06967
[...]
```